### PR TITLE
enforcement for no-throw finally actions

### DIFF
--- a/docs/headers.md
+++ b/docs/headers.md
@@ -794,7 +794,7 @@ template <class F>
 class final_action { ... };
 ```
 
-`final_action` allows you to ensure something gets run at the end of a scope.
+`final_action` allows you to ensure non-throwing code is executed at the end of a scope.
 
 See [E.19: Use a final_action object to express cleanup if no suitable resource handle is available](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Re-finally)
 
@@ -805,13 +805,13 @@ explicit final_action(const F& ff) noexcept;
 explicit final_action(F&& ff) noexcept;
 ```
 
-Construct an object with the action to invoke in the destructor.
+Construct an object with the non-throwing action to invoke in the destructor.
 
 ```cpp
 ~final_action() noexcept;
 ```
 
-The destructor will call the action that was passed in the constructor.
+The destructor will invoke the action that was passed in the constructor; if the action throws an exception the program will terminate.
 
 ```cpp
 final_action(final_action&& other) noexcept;

--- a/include/gsl/util
+++ b/include/gsl/util
@@ -69,7 +69,7 @@ namespace gsl
 // index type for all container indexes/subscripts/sizes
 using index = std::ptrdiff_t;
 
-// final_action allows you to ensure something gets run at the end of a scope
+// final_action allows you to ensure non-throwing code is executed at the end of a scope.
 template <class F>
 class final_action
 {

--- a/include/gsl/util
+++ b/include/gsl/util
@@ -73,6 +73,8 @@ using index = std::ptrdiff_t;
 template <class F>
 class final_action
 {
+	static_assert(std::is_nothrow_invocable_v<F>, "the provided action must be non-throwing");
+
 public:
     explicit final_action(const F& ff) noexcept : f{ff} { }
     explicit final_action(F&& ff) noexcept : f{std::move(ff)} { }


### PR DESCRIPTION
a throwing finally action will be accepted by the compiler but result in surprise termination at runtime; enforce that actions provided to finally must be non-throwing at compile time.
